### PR TITLE
feat: implement initial logic for running tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "tsc",
     "start": "nodemon",
     "lint": "eslint src/**/*.ts",
+    "lint:fix": "eslint src/**/*.ts --fix",
     "format": "eslint src/**/*.ts --fix",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -14,6 +15,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "@types/node": "^20.11.16",
     "@types/express": "^4.17.21",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
@@ -24,6 +26,8 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "zod": "^3.22.4",
+    "zod-express-middleware": "^1.4.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,18 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  '@types/node':
+    specifier: ^20.11.16
+    version: 20.11.16
   express:
     specifier: ^4.18.2
     version: 4.18.2
+  zod:
+    specifier: ^3.22.4
+    version: 3.22.4
+  zod-express-middleware:
+    specifier: ^1.4.0
+    version: 1.4.0(@types/express@4.17.21)(express@4.18.2)(zod@3.22.4)
 
 devDependencies:
   '@types/express':
@@ -164,13 +173,11 @@ packages:
     dependencies:
       '@types/connect': 3.4.38
       '@types/node': 20.11.16
-    dev: true
 
   /@types/connect@3.4.38:
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
     dependencies:
       '@types/node': 20.11.16
-    dev: true
 
   /@types/express-serve-static-core@4.17.43:
     resolution: {integrity: sha512-oaYtiBirUOPQGSWNGPWnzyAFJ0BP3cwvN4oWZQY+zUBwpVIGsKUkpBpSztp74drYcjavs7SKFZ4DX1V2QeN8rg==}
@@ -179,7 +186,6 @@ packages:
       '@types/qs': 6.9.11
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
-    dev: true
 
   /@types/express@4.17.21:
     resolution: {integrity: sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==}
@@ -188,11 +194,9 @@ packages:
       '@types/express-serve-static-core': 4.17.43
       '@types/qs': 6.9.11
       '@types/serve-static': 1.15.5
-    dev: true
 
   /@types/http-errors@2.0.4:
     resolution: {integrity: sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==}
-    dev: true
 
   /@types/json-schema@7.0.15:
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -200,25 +204,20 @@ packages:
 
   /@types/mime@1.3.5:
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
-    dev: true
 
   /@types/mime@3.0.4:
     resolution: {integrity: sha512-iJt33IQnVRkqeqC7PzBHPTC6fDlRNRW8vjrgqtScAhrmMwe8c4Eo7+fUGTa+XdWrpEgpyKWMYmi2dIwMAYRzPw==}
-    dev: true
 
   /@types/node@20.11.16:
     resolution: {integrity: sha512-gKb0enTmRCzXSSUJDq6/sPcqrfCv2mkkG6Jt/clpn5eiCbKTY+SgZUxo+p8ZKMof5dCp9vHQUAB7wOUTod22wQ==}
     dependencies:
       undici-types: 5.26.5
-    dev: true
 
   /@types/qs@6.9.11:
     resolution: {integrity: sha512-oGk0gmhnEJK4Yyk+oI7EfXsLayXatCWPHary1MtcmbAifkobT9cM9yutG/hZKIseOU0MqbIwQ/u2nn/Gb+ltuQ==}
-    dev: true
 
   /@types/range-parser@1.2.7:
     resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
-    dev: true
 
   /@types/semver@7.5.6:
     resolution: {integrity: sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==}
@@ -229,7 +228,6 @@ packages:
     dependencies:
       '@types/mime': 1.3.5
       '@types/node': 20.11.16
-    dev: true
 
   /@types/serve-static@1.15.5:
     resolution: {integrity: sha512-PDRk21MnK70hja/YF8AHfC7yIsiQHn1rcXx7ijCFBX/k+XQJhQT/gw3xekXKJvx+5SXaMMS8oqQy09Mzvz2TuQ==}
@@ -237,7 +235,6 @@ packages:
       '@types/http-errors': 2.0.4
       '@types/mime': 3.0.4
       '@types/node': 20.11.16
-    dev: true
 
   /@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0)(eslint@8.56.0)(typescript@5.3.3):
     resolution: {integrity: sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==}
@@ -1667,7 +1664,6 @@ packages:
 
   /undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
-    dev: true
 
   /unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -1719,3 +1715,19 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
     dev: true
+
+  /zod-express-middleware@1.4.0(@types/express@4.17.21)(express@4.18.2)(zod@3.22.4):
+    resolution: {integrity: sha512-C1pBbwbuotitG1L3I1cr9QD/nuepHAdZEUbVn7y1o2cJq0oaUuS7gTVGby1+DGHL4t2P4eEZKCX0QQDv6hEs3A==}
+    peerDependencies:
+      '@types/express': ^4.17.12
+      express: ^4.17.1
+      zod: ^3.2.0
+    dependencies:
+      '@types/express': 4.17.21
+      express: 4.18.2
+      zod: 3.22.4
+    dev: false
+
+  /zod@3.22.4:
+    resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
+    dev: false

--- a/src/app/test/request.types.ts
+++ b/src/app/test/request.types.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+export const RunTestsRequestSchema = z.object({
+  host: z.string().url(),
+  ingressProxyPath: z.string(),
+  cdnProxyPath: z.string(),
+});
+
+export type RunTestsRequest = z.infer<typeof RunTestsRequestSchema>;
+
+export const StartTestsRequestSchema = z.object({
+  host: z.string().url(),
+});
+
+export type StartTestsRequest = z.infer<typeof StartTestsRequestSchema>;

--- a/src/app/test/router.ts
+++ b/src/app/test/router.ts
@@ -1,0 +1,35 @@
+import * as express from 'express';
+import { createTestSession, getTestSession } from './service/session';
+import { RunTestsRequestSchema } from './request.types';
+import { runTests } from './service/testRunner';
+import { validateRequest } from 'zod-express-middleware';
+
+const RunTestsSchema = validateRequest({
+  body: RunTestsRequestSchema,
+});
+
+export function testRouter() {
+  const router = express.Router();
+
+  router.post('/run-tests', RunTestsSchema, async (req, res) => {
+    const testSession = createTestSession(req.body);
+
+    const result = await runTests(testSession);
+
+    return res.json(result.toJSON());
+  });
+
+  router.post('/ingress', (req, res) => {
+    const testSession = getTestSession(req.hostname);
+
+    // TODO: Notify ongoing test about this ingress request and perform necessary actions
+  });
+
+  router.get('/cdn', (req, res) => {
+    const testSession = getTestSession(req.hostname);
+
+    // TODO: Notify ongoing test about this CDN request and perform necessary actions
+  });
+
+  return router;
+}

--- a/src/app/test/service/assert.ts
+++ b/src/app/test/service/assert.ts
@@ -1,0 +1,24 @@
+import { FailedTestResult } from './testCases';
+import assertImpl from 'assert';
+
+export class AssertionError extends Error {
+  constructor(expected: unknown, actual: unknown) {
+    super(`Expected "${expected}" but got "${actual}"`);
+    this.name = 'AssertionError';
+  }
+
+  toTestResult(): FailedTestResult {
+    return {
+      passed: false,
+      reason: this.message,
+    };
+  }
+}
+
+export function assert<T>(expected: T, actual: T) {
+  try {
+    assertImpl.deepStrictEqual(expected, actual);
+  } catch {
+    throw new AssertionError(expected, actual);
+  }
+}

--- a/src/app/test/service/session.ts
+++ b/src/app/test/service/session.ts
@@ -1,0 +1,76 @@
+import { RunTestsRequest } from '../request.types';
+import { TestResult } from './testCases';
+
+export enum TestSessionStatus {
+  Created = 'created',
+  Running = 'running',
+  Finished = 'finished',
+}
+
+export class TestSession implements RunTestsRequest {
+  constructor(
+    public host: string,
+    public ingressProxyPath: string,
+    public cdnProxyPath: string,
+    public status: TestSessionStatus,
+    public results: TestResult[],
+  ) {}
+
+  start() {
+    this.status = TestSessionStatus.Running;
+  }
+
+  finish() {
+    this.status = TestSessionStatus.Finished;
+  }
+
+  addResult(result: TestResult) {
+    this.results.push(result);
+  }
+
+  toJSON() {
+    return {
+      host: this.host,
+      status: this.status,
+      results: this.results,
+    };
+  }
+}
+
+const testSessions = new Map<string, TestSession>();
+
+export function createTestSession(request: RunTestsRequest) {
+  if (testSessions.has(request.host)) {
+    throw new Error('Test session already exists');
+  }
+
+  const session = new TestSession(
+    request.host,
+    request.ingressProxyPath,
+    request.cdnProxyPath,
+    TestSessionStatus.Created,
+    [],
+  );
+
+  testSessions.set(request.host, session);
+
+  return session;
+}
+
+export function getTestSession(host: string) {
+  const testSession = testSessions.get(host);
+
+  if (!testSession) {
+    throw new Error('Test session not found');
+  }
+
+  return testSession;
+}
+
+export function finalizeTestSession(testSession: TestSession) {
+  testSession.finish();
+
+  testSessions.delete(testSession.host);
+
+  return testSession;
+}

--- a/src/app/test/service/testCases.ts
+++ b/src/app/test/service/testCases.ts
@@ -1,0 +1,47 @@
+import { Request as ExpressRequest, Response as ExpressResponse } from 'express';
+
+export type SendRequestResult = {
+  requestFromProxy: ExpressRequest;
+  // TODO: Not sure if this will be needed
+  sendResponse: (response: ExpressResponse) => void;
+};
+
+export type TestCaseApi = {
+  sendRequestToCdn: (query?: URLSearchParams, headers?: Headers) => Promise<SendRequestResult>;
+  sendRequestToIngress: (request: Request) => Promise<SendRequestResult>;
+  assert: <T>(expected: T, actual: T) => void;
+};
+
+export type FailedTestResult = {
+  passed: false;
+  reason: string;
+};
+
+export type PassedTestResult = {
+  passed: true;
+};
+
+export type TestResult = FailedTestResult | PassedTestResult;
+
+export type TestCase = {
+  name: string;
+  test: (api: TestCaseApi) => Promise<void>;
+};
+
+export const testCases: TestCase[] = [
+  {
+    name: 'agent request query params',
+    test: async (api) => {
+      const query = new URLSearchParams();
+      query.set('apiKey', 'test');
+      query.set('version', '3');
+      query.set('loaderVersion', '1');
+
+      const { requestFromProxy } = await api.sendRequestToCdn(query);
+
+      api.assert(requestFromProxy.query['apiKey'], query.get('apiKey'));
+      api.assert(requestFromProxy.query['version'], query.get('version'));
+      api.assert(requestFromProxy.query['loaderVersion'], query.get('loaderVersion'));
+    },
+  },
+];

--- a/src/app/test/service/testRunner.ts
+++ b/src/app/test/service/testRunner.ts
@@ -1,0 +1,89 @@
+import { AssertionError, assert } from './assert';
+import { TestCase, TestCaseApi, TestResult, testCases } from './testCases';
+import { TestSession, finalizeTestSession } from './session';
+import { withTimeout } from '../../../utils/timeout';
+
+const TEST_TIMEOUT_MS = 10_000;
+
+export type DetailedTestResult = TestResult & {
+  testName: string;
+  requestDurationMs: number;
+};
+
+export async function runTests(testSession: TestSession) {
+  testSession.start();
+
+  for (const test of testCases) {
+    const result = await runTest(testSession, test);
+    testSession.addResult(result);
+  }
+
+  return finalizeTestSession(testSession);
+}
+
+export async function runTest(testSession: TestSession, test: TestCase): Promise<DetailedTestResult> {
+  const startTime = Date.now();
+
+  const cdnProxyUrl = new URL(testSession.host);
+  cdnProxyUrl.pathname = testSession.cdnProxyPath;
+
+  const ingressProxyUrl = new URL(testSession.host);
+  ingressProxyUrl.pathname = testSession.ingressProxyPath;
+
+  const api: TestCaseApi = {
+    sendRequestToCdn: async (query, headers) => {
+      /**
+       * 1. Send request to proxy CDN endpoint.
+       * 2. App awaits CDN request from proxy.
+       * 3. Test runs necessary assertions.
+       * */
+      return {
+        sendResponse: () => {
+          throw new Error('Not implemented');
+        },
+        requestFromProxy: {} as any,
+      };
+    },
+    sendRequestToIngress: async () => {
+      /**
+       * 1. Send request to proxy ingress endpoint.
+       * 2. App awaits ingress request from proxy.
+       * 3. Test runs necessary assertions.
+       * */
+      return {
+        sendResponse: () => {
+          throw new Error('Not implemented');
+        },
+        requestFromProxy: {} as any,
+      };
+    },
+    assert,
+  };
+
+  let result: TestResult;
+
+  try {
+    await withTimeout(() => test.test(api), TEST_TIMEOUT_MS);
+
+    result = {
+      passed: true,
+    };
+  } catch (error) {
+    if (error instanceof AssertionError) {
+      result = error.toTestResult();
+    } else {
+      result = {
+        passed: false,
+        reason: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  const requestDurationMs = Date.now() - startTime;
+
+  return {
+    ...result,
+    testName: test.name,
+    requestDurationMs,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,12 @@
 import * as express from 'express';
 import { Express } from 'express';
 import router from './router';
+import { testRouter } from './app/test/router';
 
 const app: Express = express();
 const port = Number(process.env.APP_PORT) || 3000;
 
+app.use(express.json());
 app.use(router);
-
+app.use('/api/test', testRouter());
 app.listen(port, () => console.log(`Application started on port ${port}`));

--- a/src/utils/timeout.ts
+++ b/src/utils/timeout.ts
@@ -1,0 +1,22 @@
+export class TimeoutError extends Error {
+  constructor(ms: number) {
+    super(`Timeout of ${ms}ms exceeded`);
+    this.name = 'TimeoutError';
+  }
+}
+
+export function wait(ms: number) {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+export function withTimeout<T>(callback: () => Promise<T>, ms: number) {
+  return new Promise((resolve, reject) => {
+    wait(ms).then(() => {
+      reject(new TimeoutError(ms));
+    });
+
+    callback().then(resolve, reject);
+  });
+}


### PR DESCRIPTION
Initial logic for running test:

1. Request to `/api/test/run-tests` needs to be made. This will create a new test session, for which specified `host` will act as identifier, and then tests specified in `testCases.ts` will run.
3. There is an one test case added as example, but it won't work for now, because test runner implementation is not finished. It will be added in next PR.