### PR TITLE
fix: remove port from ip before asserting

### DIFF
--- a/src/app/test/cases/ingress/request-preserve-cookie-secret-host-headers.case.ts
+++ b/src/app/test/cases/ingress/request-preserve-cookie-secret-host-headers.case.ts
@@ -1,4 +1,4 @@
-import { assert } from '../../service/assert'
+import { assert, assertEqualIp } from '../../service/assert'
 import { TestCase } from '../../types/testCase'
 import { getIP } from '../../utils/getIP'
 
@@ -18,7 +18,7 @@ const testCase: TestCase = {
     const testSessionHost = `${testSessionHostURL.protocol}//${testSessionHostURL.host}`
 
     assert(requestFromProxy.get('x-custom-header'), '123', 'x-custom-header')
-    assert(requestFromProxy.get('fpjs-proxy-client-ip'), ipOfClient, 'fpjs-proxy-client-ip')
+    assertEqualIp(requestFromProxy.get('fpjs-proxy-client-ip'), ipOfClient, 'fpjs-proxy-client-ip')
     assert(requestFromProxy.get('cookie'), '_iidt=123', 'cookie')
     assert(requestFromProxy.get('fpjs-proxy-secret'), 'secret', 'fpjs-proxy-secret')
     assert(`https://${requestFromProxy.get('fpjs-proxy-forwarded-host')}`, testSessionHost, 'fpjs-proxy-forwarded-host')

--- a/src/app/test/service/assert.ts
+++ b/src/app/test/service/assert.ts
@@ -11,6 +11,19 @@ export function assert<T>(actual: T, expected: T, message?: string) {
   }
 }
 
+/**
+ * Removes port from IP address. Sometimes IP address is returned with port, which is not needed.
+ * */
+function removePortFromIp(ip: string) {
+  const url = new URL(`http://${ip}`)
+
+  return url.hostname
+}
+
+export function assertEqualIp(actualIp: string, expectedIp: string, message?: string) {
+  assert(removePortFromIp(actualIp), removePortFromIp(expectedIp), message)
+}
+
 export function assertLowerThanOrEqual(actual: number, expected: number, message?: string) {
   if (!(actual <= expected)) {
     throw new AssertionError({


### PR DESCRIPTION
Fixes following error (at least for Azure):
```json
{
        "error": {
          "generatedMessage": false,
          "code": "ERR_ASSERTION",
          "actual": "34.234.201.92:38764",
          "expected": "34.234.201.92",
          "operator": "assert"
        },

}
```