### PR TITLE
test: update tests for latest v4 design choices

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mock-for-e2e",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "",
   "main": "index.js",
   "engines": {

--- a/src/app/test/cases/agent/request-preserve-header-and-query.case.ts
+++ b/src/app/test/cases/agent/request-preserve-header-and-query.case.ts
@@ -1,4 +1,4 @@
-import { assert, assertToBeTruthy } from '../../service/assert'
+import { assert, assertToBeFalsy, assertToBeTruthy } from '../../service/assert'
 import { TestCase } from '../../types/testCase'
 import { getApiKey } from '../../utils/getApiKey'
 
@@ -15,16 +15,11 @@ const testCase: TestCase = {
     })
     const { ii, customQuery } = requestFromProxy.query
 
-    assertToBeTruthy('ii', ii)
+    assertToBeFalsy('ii', ii)
     assertToBeTruthy('customQuery', customQuery)
-
-    const [integration, version, type] = ii.toString().split('/')
 
     assert(requestFromProxy.get('X-Custom'), '123', 'X-Custom')
     assert(customQuery, '123', 'customQuery')
-    assert(integration, api.testSession.trafficName, 'trafficName')
-    assert(version, api.testSession.integrationVersion, 'integrationVersion')
-    assert(type, 'procdn', 'integrationType')
   },
 }
 

--- a/src/app/test/cases/agent/request-traffic-monitoring.case.ts
+++ b/src/app/test/cases/agent/request-traffic-monitoring.case.ts
@@ -1,4 +1,4 @@
-import { assert, assertToBeTruthy } from '../../service/assert'
+import { assert, assertToBeFalsy } from '../../service/assert'
 import { TestCase } from '../../types/testCase'
 import { getApiKey } from '../../utils/getApiKey'
 
@@ -12,13 +12,7 @@ const testCase: TestCase = {
     const { requestFromProxy } = await api.sendRequestToCdn({ query })
     const { ii, customQuery } = requestFromProxy.query
 
-    assertToBeTruthy('ii', ii)
-
-    const [integration, version, type] = ii.toString().split('/')
-
-    assert(integration, api.testSession.trafficName, 'trafficName')
-    assert(version, api.testSession.integrationVersion, 'integrationVersion')
-    assert(type, 'ingress', 'integrationType')
+    assertToBeFalsy('ii', ii)
     assert(customQuery, '123', 'customQuery')
   },
 }

--- a/src/app/test/cases/agent/request-v4-preserve-header-and-query.case.ts
+++ b/src/app/test/cases/agent/request-v4-preserve-header-and-query.case.ts
@@ -1,4 +1,4 @@
-import { assert, assertToBeTruthy } from '../../service/assert'
+import { assert, assertToBeFalsy, assertToBeTruthy } from '../../service/assert'
 import { TestCase } from '../../types/testCase'
 
 const testCase: TestCase = {
@@ -13,16 +13,11 @@ const testCase: TestCase = {
     })
     const { ii, customQuery } = requestFromProxy.query
 
-    assertToBeTruthy('ii', ii)
+    assertToBeFalsy('ii', ii)
     assertToBeTruthy('customQuery', customQuery)
-
-    const [integration, version, type] = ii.toString().split('/')
 
     assert(requestFromProxy.get('X-Custom'), '123', 'X-Custom')
     assert(customQuery, '123', 'customQuery')
-    assert(integration, api.testSession.trafficName, 'trafficName')
-    assert(version, api.testSession.integrationVersion, 'integrationVersion')
-    assert(type, 'procdn', 'integrationType')
   },
 }
 

--- a/src/app/test/cases/agent/request-v4-traffic-monitoring.case.ts
+++ b/src/app/test/cases/agent/request-v4-traffic-monitoring.case.ts
@@ -1,4 +1,4 @@
-import { assert, assertToBeTruthy } from '../../service/assert'
+import { assert, assertToBeFalsy } from '../../service/assert'
 import { TestCase } from '../../types/testCase'
 
 const testCase: TestCase = {
@@ -12,13 +12,7 @@ const testCase: TestCase = {
     })
     const { ii, customQuery } = requestFromProxy.query
 
-    assertToBeTruthy('ii', ii)
-
-    const [integration, version, type] = ii.toString().split('/')
-
-    assert(integration, api.testSession.trafficName, 'trafficName')
-    assert(version, api.testSession.integrationVersion, 'integrationVersion')
-    assert(type, 'ingress', 'integrationType')
+    assertToBeFalsy('ii', ii)
     assert(customQuery, '123', 'customQuery')
   },
 }


### PR DESCRIPTION
- Update query parameter expectations to no longer expect the `ii` parameter on agent requests.