### PR TITLE
Add utility to bypass caching for test case queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mock-for-e2e",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "",
   "main": "index.js",
   "engines": {

--- a/src/app/test/cases/agent/response-body-integrity-200.case.ts
+++ b/src/app/test/cases/agent/response-body-integrity-200.case.ts
@@ -2,12 +2,14 @@ import { TestCase } from '../../types/testCase'
 import { getApiKey } from '../../utils/getApiKey'
 import { assert } from '../../service/assert'
 import { diverseUnicodeJavascript } from '../../utils/diverseUnicode'
+import { withCacheDisablingQueryParam } from '../../../../utils/query'
 
 const testCase: TestCase = {
   name: 'agent response body integrity protected with 200 status code',
   test: async (api) => {
     const query = new URLSearchParams()
     query.set('apiKey', getApiKey())
+    withCacheDisablingQueryParam(query)
 
     const body = diverseUnicodeJavascript
 

--- a/src/app/test/cases/agent/response-body-integrity-200.case.ts
+++ b/src/app/test/cases/agent/response-body-integrity-200.case.ts
@@ -2,14 +2,14 @@ import { TestCase } from '../../types/testCase'
 import { getApiKey } from '../../utils/getApiKey'
 import { assert } from '../../service/assert'
 import { diverseUnicodeJavascript } from '../../utils/diverseUnicode'
-import { withCacheDisablingQueryParam } from '../../../../utils/query'
+import { disableCacheByQueryParam } from '../../../../utils/query'
 
 const testCase: TestCase = {
   name: 'agent response body integrity protected with 200 status code',
   test: async (api) => {
     const query = new URLSearchParams()
     query.set('apiKey', getApiKey())
-    withCacheDisablingQueryParam(query)
+    disableCacheByQueryParam(query)
 
     const body = diverseUnicodeJavascript
 

--- a/src/app/test/cases/agent/response-body-integrity-301.case.ts
+++ b/src/app/test/cases/agent/response-body-integrity-301.case.ts
@@ -1,12 +1,14 @@
 import { TestCase } from '../../types/testCase'
 import { getApiKey } from '../../utils/getApiKey'
 import { assert } from '../../service/assert'
+import { withCacheDisablingQueryParam } from '../../../../utils/query'
 
 const testCase: TestCase = {
   name: 'agent response body integrity protected with 301 status code',
   test: async (api) => {
     const query = new URLSearchParams()
     query.set('apiKey', getApiKey())
+    withCacheDisablingQueryParam(query)
 
     const body = ``
     const location = `https://${api.testSession.host}/path?withQuery=param#1`

--- a/src/app/test/cases/agent/response-body-integrity-301.case.ts
+++ b/src/app/test/cases/agent/response-body-integrity-301.case.ts
@@ -1,14 +1,14 @@
 import { TestCase } from '../../types/testCase'
 import { getApiKey } from '../../utils/getApiKey'
 import { assert } from '../../service/assert'
-import { withCacheDisablingQueryParam } from '../../../../utils/query'
+import { disableCacheByQueryParam } from '../../../../utils/query'
 
 const testCase: TestCase = {
   name: 'agent response body integrity protected with 301 status code',
   test: async (api) => {
     const query = new URLSearchParams()
     query.set('apiKey', getApiKey())
-    withCacheDisablingQueryParam(query)
+    disableCacheByQueryParam(query)
 
     const body = ``
     const location = `https://${api.testSession.host}/path?withQuery=param#1`

--- a/src/app/test/cases/agent/response-body-integrity-400.case.ts
+++ b/src/app/test/cases/agent/response-body-integrity-400.case.ts
@@ -2,12 +2,14 @@ import { TestCase } from '../../types/testCase'
 import { getApiKey } from '../../utils/getApiKey'
 import { assert } from '../../service/assert'
 import { diverseUnicodeJavascript } from '../../utils/diverseUnicode'
+import { withCacheDisablingQueryParam } from '../../../../utils/query'
 
 const testCase: TestCase = {
   name: 'agent response body integrity protected with 400 status code',
   test: async (api) => {
     const query = new URLSearchParams()
     query.set('apiKey', getApiKey())
+    withCacheDisablingQueryParam(query)
 
     const body = diverseUnicodeJavascript
 

--- a/src/app/test/cases/agent/response-body-integrity-400.case.ts
+++ b/src/app/test/cases/agent/response-body-integrity-400.case.ts
@@ -2,14 +2,14 @@ import { TestCase } from '../../types/testCase'
 import { getApiKey } from '../../utils/getApiKey'
 import { assert } from '../../service/assert'
 import { diverseUnicodeJavascript } from '../../utils/diverseUnicode'
-import { withCacheDisablingQueryParam } from '../../../../utils/query'
+import { disableCacheByQueryParam } from '../../../../utils/query'
 
 const testCase: TestCase = {
   name: 'agent response body integrity protected with 400 status code',
   test: async (api) => {
     const query = new URLSearchParams()
     query.set('apiKey', getApiKey())
-    withCacheDisablingQueryParam(query)
+    disableCacheByQueryParam(query)
 
     const body = diverseUnicodeJavascript
 

--- a/src/app/test/cases/agent/response-body-integrity-500.case.ts
+++ b/src/app/test/cases/agent/response-body-integrity-500.case.ts
@@ -2,12 +2,14 @@ import { TestCase } from '../../types/testCase'
 import { getApiKey } from '../../utils/getApiKey'
 import { assert } from '../../service/assert'
 import { HTML_500_ERROR } from '../../utils/constants'
+import { withCacheDisablingQueryParam } from '../../../../utils/query'
 
 const testCase: TestCase = {
   name: 'agent response body integrity protected with 500 status code',
   test: async (api) => {
     const query = new URLSearchParams()
     query.set('apiKey', getApiKey())
+    withCacheDisablingQueryParam(query)
 
     const body = HTML_500_ERROR
 

--- a/src/app/test/cases/agent/response-body-integrity-500.case.ts
+++ b/src/app/test/cases/agent/response-body-integrity-500.case.ts
@@ -2,14 +2,14 @@ import { TestCase } from '../../types/testCase'
 import { getApiKey } from '../../utils/getApiKey'
 import { assert } from '../../service/assert'
 import { HTML_500_ERROR } from '../../utils/constants'
-import { withCacheDisablingQueryParam } from '../../../../utils/query'
+import { disableCacheByQueryParam } from '../../../../utils/query'
 
 const testCase: TestCase = {
   name: 'agent response body integrity protected with 500 status code',
   test: async (api) => {
     const query = new URLSearchParams()
     query.set('apiKey', getApiKey())
-    withCacheDisablingQueryParam(query)
+    disableCacheByQueryParam(query)
 
     const body = HTML_500_ERROR
 

--- a/src/app/test/cases/agent/response-cache-control-preserved.case.ts
+++ b/src/app/test/cases/agent/response-cache-control-preserved.case.ts
@@ -1,12 +1,14 @@
 import { TestCase } from '../../types/testCase'
 import { getApiKey } from '../../utils/getApiKey'
 import { assertToBeTruthy } from '../../service/assert'
+import { withCacheDisablingQueryParam } from '../../../../utils/query'
 
 const testCase: TestCase = {
   name: 'agent response cache-control preserved or in-limit',
   test: async (api) => {
     const query = new URLSearchParams()
     query.set('apiKey', getApiKey())
+    withCacheDisablingQueryParam(query)
     const { responseFromProxy } = await api.sendRequestToCdn({
       query,
 

--- a/src/app/test/cases/agent/response-cache-control-preserved.case.ts
+++ b/src/app/test/cases/agent/response-cache-control-preserved.case.ts
@@ -1,14 +1,14 @@
 import { TestCase } from '../../types/testCase'
 import { getApiKey } from '../../utils/getApiKey'
 import { assertToBeTruthy } from '../../service/assert'
-import { withCacheDisablingQueryParam } from '../../../../utils/query'
+import { disableCacheByQueryParam } from '../../../../utils/query'
 
 const testCase: TestCase = {
   name: 'agent response cache-control preserved or in-limit',
   test: async (api) => {
     const query = new URLSearchParams()
     query.set('apiKey', getApiKey())
-    withCacheDisablingQueryParam(query)
+    disableCacheByQueryParam(query)
     const { responseFromProxy } = await api.sendRequestToCdn({
       query,
 

--- a/src/app/test/cases/agent/response-no-unintended-header-modifications.case.ts
+++ b/src/app/test/cases/agent/response-no-unintended-header-modifications.case.ts
@@ -1,12 +1,14 @@
 import { TestCase } from '../../types/testCase'
 import { getApiKey } from '../../utils/getApiKey'
 import { assert } from '../../service/assert'
+import { withCacheDisablingQueryParam } from '../../../../utils/query'
 
 const testCase: TestCase = {
   name: 'agent response no unintended header modifications',
   test: async (api) => {
     const query = new URLSearchParams()
     query.set('apiKey', getApiKey())
+    withCacheDisablingQueryParam(query)
     const { responseFromProxy } = await api.sendRequestToCdn({
       query,
 

--- a/src/app/test/cases/agent/response-no-unintended-header-modifications.case.ts
+++ b/src/app/test/cases/agent/response-no-unintended-header-modifications.case.ts
@@ -1,14 +1,14 @@
 import { TestCase } from '../../types/testCase'
 import { getApiKey } from '../../utils/getApiKey'
 import { assert } from '../../service/assert'
-import { withCacheDisablingQueryParam } from '../../../../utils/query'
+import { disableCacheByQueryParam } from '../../../../utils/query'
 
 const testCase: TestCase = {
   name: 'agent response no unintended header modifications',
   test: async (api) => {
     const query = new URLSearchParams()
     query.set('apiKey', getApiKey())
-    withCacheDisablingQueryParam(query)
+    disableCacheByQueryParam(query)
     const { responseFromProxy } = await api.sendRequestToCdn({
       query,
 

--- a/src/app/test/cases/agent/response-successful-response-passthrough.case.ts
+++ b/src/app/test/cases/agent/response-successful-response-passthrough.case.ts
@@ -1,12 +1,14 @@
 import { TestCase } from '../../types/testCase'
 import { getApiKey } from '../../utils/getApiKey'
 import { assert } from '../../service/assert'
+import { withCacheDisablingQueryParam } from '../../../../utils/query'
 
 const testCase: TestCase = {
   name: 'agent response successful response passthrough',
   test: async (api) => {
     const query = new URLSearchParams()
     query.set('apiKey', getApiKey())
+    withCacheDisablingQueryParam(query)
     const { responseFromProxy } = await api.sendRequestToCdn({
       query,
 

--- a/src/app/test/cases/agent/response-successful-response-passthrough.case.ts
+++ b/src/app/test/cases/agent/response-successful-response-passthrough.case.ts
@@ -1,14 +1,14 @@
 import { TestCase } from '../../types/testCase'
 import { getApiKey } from '../../utils/getApiKey'
 import { assert } from '../../service/assert'
-import { withCacheDisablingQueryParam } from '../../../../utils/query'
+import { disableCacheByQueryParam } from '../../../../utils/query'
 
 const testCase: TestCase = {
   name: 'agent response successful response passthrough',
   test: async (api) => {
     const query = new URLSearchParams()
     query.set('apiKey', getApiKey())
-    withCacheDisablingQueryParam(query)
+    disableCacheByQueryParam(query)
     const { responseFromProxy } = await api.sendRequestToCdn({
       query,
 

--- a/src/utils/query.ts
+++ b/src/utils/query.ts
@@ -1,0 +1,5 @@
+export function withCacheDisablingQueryParam(query: URLSearchParams) {
+  // Proxy integration should use `loaderVersion` and `version` as cache key,
+  // Providing a random value will ensure that the request it not cached
+  query.set('loaderVersion', Date.now().toString())
+}

--- a/src/utils/query.ts
+++ b/src/utils/query.ts
@@ -1,5 +1,7 @@
+import { randomUUID } from 'crypto'
+
 export function withCacheDisablingQueryParam(query: URLSearchParams) {
   // Proxy integration should use `loaderVersion` and `version` as cache key,
   // Providing a random value will ensure that the request it not cached
-  query.set('loaderVersion', Date.now().toString())
+  query.set('loaderVersion', randomUUID())
 }

--- a/src/utils/query.ts
+++ b/src/utils/query.ts
@@ -2,6 +2,6 @@ import { randomUUID } from 'crypto'
 
 export function withCacheDisablingQueryParam(query: URLSearchParams) {
   // Proxy integration should use `loaderVersion` and `version` as cache key,
-  // Providing a random value will ensure that the request it not cached
+  // Providing a random value will ensure that the request is not cached
   query.set('loaderVersion', randomUUID())
 }

--- a/src/utils/query.ts
+++ b/src/utils/query.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'crypto'
 
-export function withCacheDisablingQueryParam(query: URLSearchParams) {
+export function disableCacheByQueryParam(query: URLSearchParams) {
   // Proxy integration should use `loaderVersion` and `version` as cache key,
   // Providing a random value will ensure that the request is not cached
   query.set('loaderVersion', randomUUID())


### PR DESCRIPTION
This pull request introduces the `disableCacheByQueryParam` utility, which allows disabling caching for agent requests v3.