### PR TITLE
Apply mock response status code

### DIFF
--- a/src/app/proxy-receiver/router.ts
+++ b/src/app/proxy-receiver/router.ts
@@ -50,8 +50,10 @@ function handleProxyRequest(req: express.Request, res: express.Response, next: e
     res.setHeader('cache-control', 'no-cache, no-store')
   }
 
+  res.status(mockResponse?.status ?? 200)
+
   if (mockResponse?.body) {
-    return res.status(mockResponse.status ?? 200).send(mockResponse.body)
+    return res.send(mockResponse.body)
   }
 
   return res.send()

--- a/src/app/proxy-receiver/router.ts
+++ b/src/app/proxy-receiver/router.ts
@@ -52,7 +52,7 @@ function handleProxyRequest(req: express.Request, res: express.Response, next: e
 
   res.status(mockResponse?.status ?? 200)
 
-  if (mockResponse?.body) {
+  if (mockResponse?.body !== undefined) {
     return res.send(mockResponse.body)
   }
 


### PR DESCRIPTION
## Why

The mock server should reflect whatever status code a test case configures, regardless of whether the response body is empty or not. This is important for testing redirect responses (3xx), error responses with no body, and any other case where the status code carries meaning independent of the body.

> [!NOTE]
> no `const response = res.status(...)` since `res.status()` mutates `res` object in place, storing the return value would just be an alias for the same object anyway.