### PR TITLE
feat: add support for arbitrary V4 ingress requests with HEAD and PUT test cases

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mock-for-e2e",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "",
   "main": "index.js",
   "engines": {

--- a/src/app/test/cases/ingress/request-v4-arbitrary-head-request.case.ts
+++ b/src/app/test/cases/ingress/request-v4-arbitrary-head-request.case.ts
@@ -16,7 +16,7 @@ const testCase: TestCase = {
 
     // Method and path should reach us as is.
     assert(requestFromProxy.method, 'HEAD', 'method')
-    assertToBeTruthy('path', requestFromProxy.path.includes('some_path'))
+    assertToBeTruthy('path', requestFromProxy.path === '/some_path')
 
     // Custom header should be preserved.
     assert(requestFromProxy.get('x-custom-header'), '123', 'x-custom-header')

--- a/src/app/test/cases/ingress/request-v4-arbitrary-head-request.case.ts
+++ b/src/app/test/cases/ingress/request-v4-arbitrary-head-request.case.ts
@@ -1,0 +1,32 @@
+import { assert, assertToBeFalsy, assertToBeTruthy } from '../../service/assert'
+import { TestCase } from '../../types/testCase'
+
+const testCase: TestCase = {
+  name: 'v4 ingress arbitrary HEAD request',
+  test: async (api) => {
+    const { requestFromProxy } = await api.sendArbitraryRequestToV4Ingress({
+      method: 'HEAD',
+      path: '/some_path',
+      request: {
+        headers: {
+          'x-custom-header': '123',
+        },
+      },
+    })
+
+    // Method and path should reach us as is.
+    assert(requestFromProxy.method, 'HEAD', 'method')
+    assertToBeTruthy('path', requestFromProxy.path.includes('some_path'))
+
+    // Custom header should be preserved.
+    assert(requestFromProxy.get('x-custom-header'), '123', 'x-custom-header')
+
+    assertToBeFalsy('fpjs-proxy-forwarded-host', requestFromProxy.get('fpjs-proxy-forwarded-host'))
+
+    // ii query param should not be added by the integration, it should only happen for POST requests
+    const { ii } = requestFromProxy.query
+    assertToBeFalsy('ii', ii)
+  },
+}
+
+export default testCase

--- a/src/app/test/cases/ingress/request-v4-arbitrary-head-request.case.ts
+++ b/src/app/test/cases/ingress/request-v4-arbitrary-head-request.case.ts
@@ -1,12 +1,16 @@
-import { assert, assertToBeFalsy, assertToBeTruthy } from '../../service/assert'
+import { assert, assertToBeFalsy } from '../../service/assert'
 import { TestCase } from '../../types/testCase'
 
 const testCase: TestCase = {
   name: 'v4 ingress arbitrary HEAD request',
   test: async (api) => {
+    const query = new URLSearchParams()
+    query.set('customQuery', '123')
+
     const { requestFromProxy } = await api.sendArbitraryRequestToV4Ingress({
       method: 'HEAD',
       path: '/some_path',
+      query,
       request: {
         headers: {
           'x-custom-header': '123',
@@ -16,15 +20,18 @@ const testCase: TestCase = {
 
     // Method and path should reach us as is.
     assert(requestFromProxy.method, 'HEAD', 'method')
-    assertToBeTruthy('path', requestFromProxy.path === '/some_path')
+    assert(requestFromProxy.path, '/some_path', 'path')
 
     // Custom header should be preserved.
     assert(requestFromProxy.get('x-custom-header'), '123', 'x-custom-header')
 
+    // Arbitrary query parameter should be preserved.
+    const { ii, customQuery } = requestFromProxy.query
+    assert(`${customQuery}`, '123', 'customQuery')
+
     // ii query param and fpjs headers should not be added by the integration, it should only happen for POST requests
     assertToBeFalsy('fpjs-proxy-forwarded-host', requestFromProxy.get('fpjs-proxy-forwarded-host'))
     assertToBeFalsy('fpjs-proxy-secret', requestFromProxy.get('fpjs-proxy-secret'))
-    const { ii } = requestFromProxy.query
     assertToBeFalsy('ii', ii)
   },
 }

--- a/src/app/test/cases/ingress/request-v4-arbitrary-head-request.case.ts
+++ b/src/app/test/cases/ingress/request-v4-arbitrary-head-request.case.ts
@@ -21,9 +21,9 @@ const testCase: TestCase = {
     // Custom header should be preserved.
     assert(requestFromProxy.get('x-custom-header'), '123', 'x-custom-header')
 
+    // ii query param and fpjs headers should not be added by the integration, it should only happen for POST requests
     assertToBeFalsy('fpjs-proxy-forwarded-host', requestFromProxy.get('fpjs-proxy-forwarded-host'))
-
-    // ii query param should not be added by the integration, it should only happen for POST requests
+    assertToBeFalsy('fpjs-proxy-secret', requestFromProxy.get('fpjs-proxy-secret'))
     const { ii } = requestFromProxy.query
     assertToBeFalsy('ii', ii)
   },

--- a/src/app/test/cases/ingress/request-v4-arbitrary-put-request-binary-body.case.ts
+++ b/src/app/test/cases/ingress/request-v4-arbitrary-put-request-binary-body.case.ts
@@ -27,11 +27,9 @@ const testCase: TestCase = {
     assertToBeTruthy('body is buffer', Buffer.isBuffer(requestFromProxy.body))
     assert(Buffer.compare(requestFromProxy.body, body), 0, 'body')
 
-    // fpjs headers should be added by the integration.
+    // ii query param and fpjs headers should not be added by the integration, it should only happen for POST requests
     assertToBeFalsy('fpjs-proxy-forwarded-host', requestFromProxy.get('fpjs-proxy-forwarded-host'))
     assertToBeFalsy('fpjs-proxy-secret', requestFromProxy.get('fpjs-proxy-secret'))
-
-    // ii query param should not be added by the integration, it should only happen for POST requests
     const { ii } = requestFromProxy.query
     assertToBeFalsy('ii', ii)
   },

--- a/src/app/test/cases/ingress/request-v4-arbitrary-put-request-binary-body.case.ts
+++ b/src/app/test/cases/ingress/request-v4-arbitrary-put-request-binary-body.case.ts
@@ -6,9 +6,13 @@ const testCase: TestCase = {
   test: async (api) => {
     const body = Buffer.from([0x00, 0x01, 0x02, 0xfd, 0xfe, 0xff])
 
+    const query = new URLSearchParams()
+    query.set('customQuery', '123')
+
     const { requestFromProxy } = await api.sendArbitraryRequestToV4Ingress({
       method: 'PUT',
       path: '/some_path',
+      query,
       request: {
         headers: {
           'content-type': 'application/octet-stream',
@@ -20,17 +24,20 @@ const testCase: TestCase = {
 
     // Method and path should reach us as is.
     assert(requestFromProxy.method, 'PUT', 'method')
-    assertToBeTruthy('path', requestFromProxy.path === '/some_path')
+    assert(requestFromProxy.path, '/some_path', 'path')
 
     // Custom header and binary body should be preserved.
     assert(requestFromProxy.get('x-custom-header'), '123', 'x-custom-header')
     assertToBeTruthy('body is buffer', Buffer.isBuffer(requestFromProxy.body))
     assert(Buffer.compare(requestFromProxy.body, body), 0, 'body')
 
+    // Arbitrary query parameter should be preserved.
+    const { ii, customQuery } = requestFromProxy.query
+    assert(`${customQuery}`, '123', 'customQuery')
+
     // ii query param and fpjs headers should not be added by the integration, it should only happen for POST requests
     assertToBeFalsy('fpjs-proxy-forwarded-host', requestFromProxy.get('fpjs-proxy-forwarded-host'))
     assertToBeFalsy('fpjs-proxy-secret', requestFromProxy.get('fpjs-proxy-secret'))
-    const { ii } = requestFromProxy.query
     assertToBeFalsy('ii', ii)
   },
 }

--- a/src/app/test/cases/ingress/request-v4-arbitrary-put-request-binary-body.case.ts
+++ b/src/app/test/cases/ingress/request-v4-arbitrary-put-request-binary-body.case.ts
@@ -1,0 +1,40 @@
+import { assert, assertToBeFalsy, assertToBeTruthy } from '../../service/assert'
+import { TestCase } from '../../types/testCase'
+
+const testCase: TestCase = {
+  name: 'v4 ingress arbitrary PUT request with binary body',
+  test: async (api) => {
+    const body = Buffer.from([0x00, 0x01, 0x02, 0xfd, 0xfe, 0xff])
+
+    const { requestFromProxy } = await api.sendArbitraryRequestToV4Ingress({
+      method: 'PUT',
+      path: '/some_path',
+      request: {
+        headers: {
+          'content-type': 'application/octet-stream',
+          'x-custom-header': '123',
+        },
+        data: body,
+      },
+    })
+
+    // Method and path should reach us as is.
+    assert(requestFromProxy.method, 'PUT', 'method')
+    assertToBeTruthy('path', requestFromProxy.path === '/some_path')
+
+    // Custom header and binary body should be preserved.
+    assert(requestFromProxy.get('x-custom-header'), '123', 'x-custom-header')
+    assertToBeTruthy('body is buffer', Buffer.isBuffer(requestFromProxy.body))
+    assert(Buffer.compare(requestFromProxy.body, body), 0, 'body')
+
+    // fpjs headers should be added by the integration.
+    assertToBeFalsy('fpjs-proxy-forwarded-host', requestFromProxy.get('fpjs-proxy-forwarded-host'))
+    assertToBeFalsy('fpjs-proxy-secret', requestFromProxy.get('fpjs-proxy-secret'))
+
+    // ii query param should not be added by the integration, it should only happen for POST requests
+    const { ii } = requestFromProxy.query
+    assertToBeFalsy('ii', ii)
+  },
+}
+
+export default testCase

--- a/src/app/test/cases/ingress/request-v4-arbitrary-put-request.case.ts
+++ b/src/app/test/cases/ingress/request-v4-arbitrary-put-request.case.ts
@@ -1,0 +1,39 @@
+import { assert, assertToBeFalsy, assertToBeTruthy } from '../../service/assert'
+import { TestCase } from '../../types/testCase'
+
+const testCase: TestCase = {
+  name: 'v4 ingress arbitrary PUT request',
+  test: async (api) => {
+    const body = { hello: 'world', nested: { value: 123 } }
+
+    const { requestFromProxy } = await api.sendArbitraryRequestToV4Ingress({
+      method: 'PUT',
+      path: '/some_path',
+      request: {
+        headers: {
+          'content-type': 'application/json',
+          'x-custom-header': '123',
+        },
+        data: body,
+      },
+    })
+
+    // Method and path should reach us as is.
+    assert(requestFromProxy.method, 'PUT', 'method')
+    assertToBeTruthy('path', requestFromProxy.path.includes('some_path'))
+
+    // Custom header and body should be preserved.
+    assert(requestFromProxy.get('x-custom-header'), '123', 'x-custom-header')
+    assert(JSON.stringify(requestFromProxy.body), JSON.stringify(body), 'body')
+
+    // fpjs headers should be added by the integration.
+    assertToBeFalsy('fpjs-proxy-forwarded-host', requestFromProxy.get('fpjs-proxy-forwarded-host'))
+    assertToBeFalsy('fpjs-proxy-secret', requestFromProxy.get('fpjs-proxy-secret'))
+
+    // ii query param should not be added by the integration, it should only happen for POST requests
+    const { ii } = requestFromProxy.query
+    assertToBeFalsy('ii', ii)
+  },
+}
+
+export default testCase

--- a/src/app/test/cases/ingress/request-v4-arbitrary-put-request.case.ts
+++ b/src/app/test/cases/ingress/request-v4-arbitrary-put-request.case.ts
@@ -26,11 +26,9 @@ const testCase: TestCase = {
     assert(requestFromProxy.get('x-custom-header'), '123', 'x-custom-header')
     assert(JSON.stringify(requestFromProxy.body), JSON.stringify(body), 'body')
 
-    // fpjs headers should be added by the integration.
+    // ii query param and fpjs headers should not be added by the integration, it should only happen for POST requests
     assertToBeFalsy('fpjs-proxy-forwarded-host', requestFromProxy.get('fpjs-proxy-forwarded-host'))
     assertToBeFalsy('fpjs-proxy-secret', requestFromProxy.get('fpjs-proxy-secret'))
-
-    // ii query param should not be added by the integration, it should only happen for POST requests
     const { ii } = requestFromProxy.query
     assertToBeFalsy('ii', ii)
   },

--- a/src/app/test/cases/ingress/request-v4-arbitrary-put-request.case.ts
+++ b/src/app/test/cases/ingress/request-v4-arbitrary-put-request.case.ts
@@ -1,4 +1,4 @@
-import { assert, assertToBeFalsy, assertToBeTruthy } from '../../service/assert'
+import { assert, assertToBeFalsy } from '../../service/assert'
 import { TestCase } from '../../types/testCase'
 
 const testCase: TestCase = {
@@ -6,9 +6,13 @@ const testCase: TestCase = {
   test: async (api) => {
     const body = { hello: 'world', nested: { value: 123 } }
 
+    const query = new URLSearchParams()
+    query.set('customQuery', '123')
+
     const { requestFromProxy } = await api.sendArbitraryRequestToV4Ingress({
       method: 'PUT',
       path: '/some_path',
+      query,
       request: {
         headers: {
           'content-type': 'application/json',
@@ -20,16 +24,19 @@ const testCase: TestCase = {
 
     // Method and path should reach us as is.
     assert(requestFromProxy.method, 'PUT', 'method')
-    assertToBeTruthy('path', requestFromProxy.path === '/some_path')
+    assert(requestFromProxy.path, '/some_path', 'path')
 
     // Custom header and body should be preserved.
     assert(requestFromProxy.get('x-custom-header'), '123', 'x-custom-header')
     assert(JSON.stringify(requestFromProxy.body), JSON.stringify(body), 'body')
 
+    // Arbitrary query parameter should be preserved.
+    const { ii, customQuery } = requestFromProxy.query
+    assert(`${customQuery}`, '123', 'customQuery')
+
     // ii query param and fpjs headers should not be added by the integration, it should only happen for POST requests
     assertToBeFalsy('fpjs-proxy-forwarded-host', requestFromProxy.get('fpjs-proxy-forwarded-host'))
     assertToBeFalsy('fpjs-proxy-secret', requestFromProxy.get('fpjs-proxy-secret'))
-    const { ii } = requestFromProxy.query
     assertToBeFalsy('ii', ii)
   },
 }

--- a/src/app/test/cases/ingress/request-v4-arbitrary-put-request.case.ts
+++ b/src/app/test/cases/ingress/request-v4-arbitrary-put-request.case.ts
@@ -20,7 +20,7 @@ const testCase: TestCase = {
 
     // Method and path should reach us as is.
     assert(requestFromProxy.method, 'PUT', 'method')
-    assertToBeTruthy('path', requestFromProxy.path.includes('some_path'))
+    assertToBeTruthy('path', requestFromProxy.path === '/some_path')
 
     // Custom header and body should be preserved.
     assert(requestFromProxy.get('x-custom-header'), '123', 'x-custom-header')

--- a/src/app/test/service/TestCaseApi.ts
+++ b/src/app/test/service/TestCaseApi.ts
@@ -54,6 +54,14 @@ interface RequestToIngressParams {
   mockResponse?: MockResponse
 }
 
+interface ArbitraryV4RequestParams {
+  method: Method
+  path?: string
+  request?: Partial<AxiosRequestConfig>
+  query?: URLSearchParams
+  mockResponse?: MockResponse
+}
+
 export class TestCaseApi {
   readonly requestsFromProxy: RequestsFromProxyRecord = {
     [ProxyRequestType.Cdn]: [],
@@ -303,6 +311,28 @@ export class TestCaseApi {
     const result = await this.sendRequest({
       method: 'POST',
       path: '/',
+      query,
+      requestConfig: request,
+      listenerType: ProxyRequestType.Ingress,
+      mockResponse,
+    })
+
+    if (!result.requestFromProxy) {
+      throw new NoProxyRequestReceivedError(result.requestSentToProxy, result.responseFromProxy)
+    }
+    return result
+  }
+
+  async sendArbitraryRequestToV4Ingress({
+    method,
+    path = '/',
+    request,
+    query,
+    mockResponse,
+  }: ArbitraryV4RequestParams): Promise<SendRequestResult> {
+    const result = await this.sendRequest({
+      method,
+      path,
       query,
       requestConfig: request,
       listenerType: ProxyRequestType.Ingress,

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,8 @@ installLogger({
 app.set('view engine', 'ejs')
 
 app.use(express.json())
+// Needed for test cases that send and expect binary bodies
+app.use(express.raw({ type: 'application/octet-stream' }))
 app.use(beforeResponseMiddleware(console.info))
 
 app.use(proxyReceiverRouter())


### PR DESCRIPTION
This pull request introduces new test cases for arbitrary HTTP methods (HEAD and PUT) to the v4 ingress endpoint.

**Test case additions:**

- Added a new test case for sending an arbitrary HEAD request to the v4 ingress, verifying method, path, headers, and query parameters are handled as expected (`request-v4-arbitrary-head-request.case.ts`).
- Added a new test case for sending an arbitrary PUT request to the v4 ingress, including checks for method, path, headers, body, and query parameters (`request-v4-arbitrary-put-request.case.ts`).
- Added a new test case for sending an arbitrary PUT request with a binary body (`application/octet-stream`) to the v4 ingress, verifying the binary body is preserved byte-for-byte alongside method, path, headers, and query parameters (`request-v4-arbitrary-put-request-binary-body.case.ts`).

**Test API enhancements:**

- Introduced the `ArbitraryV4RequestParams` interface to support arbitrary HTTP method requests in the test API (`TestCaseApi.ts`).
- Added the `sendArbitraryRequestToV4Ingress` method to `TestCaseApi`, enabling tests to send requests with any HTTP method, custom headers, body, and query parameters to the v4 ingress endpoint (`TestCaseApi.ts`).

**Other:**

- Mounted an `express.raw({ type: 'application/octet-stream' })` body parser so the mock captures binary request bodies for the new test case; scoped to `application/octet-stream` only, so JSON and other existing tests are unaffected (`index.ts`).
- Bumped the package version from `0.5.1` to `0.6.0` in `package.json` to reflect the new features.

**Test proof:**
- Tested with Cloudflare integration: 
<img width="608" height="234" alt="image" src="https://github.com/user-attachments/assets/218269b7-6c3a-46b5-b40c-c289e6da25ad" />

